### PR TITLE
Use correct middleware to visit CP route

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -11,7 +11,7 @@
 
 use OptimoApps\RichSnippet\Http\Controllers\RichSnippetController;
 
-Route::middleware('web')->group(function () {
+Route::middleware('statamic.cp.authenticated')->group(function () {
     Route::get('/optimoapps/richsnippet/', [RichSnippetController::class, 'index'])->name('optimoapps.rich-snippet.index');
     Route::post('/optimoapps/richsnippet/', [RichSnippetController::class, 'update'])->name('optimoapps.rich-snippet.update');
 });


### PR DESCRIPTION
When using the web middleware, you get logged out when clicking the menu item.
This adds the correct middleware to save the session.